### PR TITLE
bugfix/fix redis not connecting during testing

### DIFF
--- a/controllers/EmailController.js
+++ b/controllers/EmailController.js
@@ -1,57 +1,28 @@
 const nodemailer = require("nodemailer");
-const Bull = require("bull")
+const Bull = require("bull");
 
 const emailQueue = new Bull("email", {
-  redis : "localhost:6379",
-})
-const sendNewEmail = (email) => {
-  emailQueue.add({...email});
-}
-const sendEmail = async (req, res) => {
-  const { from, to, subject, text } = req.body;
-  await sendNewEmail({from,to,subject,text});
-  console.log("added to queue")
-  res.json({
-    message: "added to queue",
-  });
-  // const testAccount = await nodemailer.createTestAccount();
+  // use your redis connection URL
+  redis: "redis://127.0.0.1:6379",
+});
 
-  // const transporter = nodemailer.createTransport({
-  //   host: "smtp.ethereal.email",
-  //   port: 587,
-  //   secure: false,
-  //   auth: {
-  //     user: testAccount.user,
-  //     pass: testAccount.pass,
-  //   },
-  //   tls: {
-  //     rejectUnauthorized: false,
-  //   },
-  // });
-
-  // console.log(`Sending mail to ${to}`);
-
-  // let info = await transporter.sendMail({
-  //   from,
-  //   to,
-  //   subject,
-  //   text,
-  //   html: `<strong>${text}</strong>`,
-  // });
-
-  // console.log(`Message sent: ${info.messageId}`);
-  // console.log(`Preview url: ${nodemailer.getTestMessageUrl(info)}`);
-
-  // res.json({
-  //   message: "Email Sent",
-  //   messageId: info.messageId,
-  //   previewUrl: nodemailer.getTestMessageUrl(info),
-  // });
+const sendNewEmail = async (email) => {
+  await emailQueue.add({ ...email });
 };
 
 module.exports = {
   get: (req, res) => {
     res.send("This is get request from EmailController");
   },
-  post: sendEmail,
+  post: async (req, res) => {
+    const { from, to, subject, text } = req.body;
+
+    await sendNewEmail({ from, to, subject, text });
+
+    console.log("Added to queue");
+
+    res.json({
+      message: "Email Sent",
+    });
+  },
 };

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const PORT = process.env.PORT || 4300;
 app.use(bodyParser.json());
 app.use("/email", emailRouter);
 
-
 app.listen(PORT, () => {
   console.log(`Sever started at http://localhost:${PORT}`);
 });


### PR DESCRIPTION
The emails were not queuing while testing. Solution was to install redis locally in a wsl environment and replace the connection url with "redis://127.0.0.1:6379.
This should be replaced to the corresponding connection url (which is stored as an environment variable) while deploying.